### PR TITLE
Update General  Properties section for the Aggregation Comparison rule page

### DIFF
--- a/docs/checks/aggregation-comparison-check.md
+++ b/docs/checks/aggregation-comparison-check.md
@@ -18,8 +18,8 @@ By setting a comparison between aggregates from potentially different tables or 
 
 {%
     include-markdown "components/general-props/index.md"
-    start='<!-- all-props--start -->'
-    end='<!-- all-props--end -->'
+    start='<!-- filter-only--start -->'
+    end='<!-- filter-only--end -->'
 %}
 
 ### Specific Properties


### PR DESCRIPTION
### Overview

The "Aggregation Comparison" rule does not utilize the "Coverage" parameter, and its presence in can lead to misunderstanding. Thus this change adjusts the content accordantly.