### PR TITLE
added message about where logs go for operation errors

### DIFF
--- a/docs/cli/overview-of-qualytics-cli.md
+++ b/docs/cli/overview-of-qualytics-cli.md
@@ -210,6 +210,7 @@ qualytics run scan
 | `--greater_than_batch`                 | FLOAT    | Only include rows where the incremental field's value is greater than this number                                                                | No       |
 | `--background`                         | BOOL     | Starts the catalog but does not wait for the operation to finish                                                                                 | No       |
 
+_Note_: Errors during any of the three operations will be logged in `$HOME/.qualytics/operation-error.log`.
 
 ### Check Operation Status
 


### PR DESCRIPTION
Very small change. Added a line to say if an operation fails or has errors, it will be logged at the corresponding file