### PR TITLE
QUA-688: Remove some pages that should not appear in search

### DIFF
--- a/docs/components/anomaly-support/index.md
+++ b/docs/components/anomaly-support/index.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 <!-- all-types--start -->
 | Type    | Supported                |
 |---------|--------------------------|

--- a/docs/components/comparators/duration.md
+++ b/docs/components/comparators/duration.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 #### Duration
 
 Duration comparators support time-based comparisons, allowing for flexibility in how duration differences are managed. This flexibility is crucial for datasets where time measurements are essential but can vary slightly.

--- a/docs/components/comparators/index.md
+++ b/docs/components/comparators/index.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 <div style="margin-top: -12px;">
 ### Comparators
 </div>

--- a/docs/components/comparators/numeric.md
+++ b/docs/components/comparators/numeric.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 #### Numeric
 
 Numeric comparators enable you to compare numbers with a specified margin, which can be a fixed absolute value or a percentage. This allows for minor numerical differences that are often acceptable in real-world data.

--- a/docs/components/comparators/numeric.md
+++ b/docs/components/comparators/numeric.md
@@ -21,7 +21,7 @@ The threshold is the value you set to define the margin of error:
 
 ??? example "Illustration using Absolute Value"
     
-    In this example, it is being compared `Value A` and `Value B` according to the defined **Threshold** of **50**.
+    In this example, it compares `Value A` and `Value B` according to the defined **Threshold** of **50**.
 
     | Value A | Value B | Difference | Are equal? |
     |---------|---------|------------|------------------|
@@ -33,7 +33,7 @@ The threshold is the value you set to define the margin of error:
 
 ??? example "Illustration using Percentage Value"
 
-    In this example, it is being compared `Value A` and `Value B` according to the defined **Threshold** of **10%**.
+    In this example, it compares `Value A` and `Value B` according to the defined **Threshold** of **10%**.
 
     **Percentage Change Formula**: [ (`Value B` - `Value A`) / `Value A` ] * 100
 

--- a/docs/components/comparators/string.md
+++ b/docs/components/comparators/string.md
@@ -13,7 +13,7 @@ When enabled, this setting allows the comparator to ignore differences in whites
 
 ??? example "Illustration"
 
-    In this example, it is being compared `Value A` and `Value B` according to the defined string comparison to `ignore whitespace` as `True`.
+    In this example, it compares `Value A` and `Value B` according to the defined string comparison to `ignore whitespace` as `True`.
 
     | Value A   | Value B   | Are equal?                              | Has whitespace?|
     |-----------|-----------|-----------------------------------------|----------------|

--- a/docs/components/comparators/string.md
+++ b/docs/components/comparators/string.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 #### String
 
 String comparators facilitate comparisons of textual data by allowing variations in spacing. This capability is essential for ensuring data consistency, particularly where minor text inconsistencies may occur.

--- a/docs/components/general-props/filter-guide.md
+++ b/docs/components/general-props/filter-guide.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 The filter allows you to define a subset of data upon which the rule will operate.
 
 It requires a valid **Spark SQL** expression that determines the criteria rows in the DataFrame should meet. This means the expression specifies which rows the DataFrame should include based on those criteria. Since it's applied directly to the Spark DataFrame, traditional SQL constructs like WHERE clauses **are not** supported.

--- a/docs/components/general-props/index.md
+++ b/docs/components/general-props/index.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 <!-- all-props--start -->
 === "Details"
     | Name    | Supported                |


### PR DESCRIPTION
### Overview

<!-- Briefly describe the purpose of this PR. -->
This PR adds a property to exclude specific documentation pages from appearing in search results, preventing users from finding internal component documentation pages.

### Key Changes

<!-- List the key features or bug fixes. Add a brief description if needed. -->
- Added search exclusion property: Implemented property to hide the following pages from search results:
  - `docs/components/anomaly-support/index.md`
  - `docs/components/comparators/duration.md`
  - `docs/components/comparators/index.md`
  - `docs/components/comparators/numeric.md`
  - `docs/components/comparators/string.md`
  - `docs/components/general-props/filter-guide.md`
  - `docs/components/general-props/index.md`