### PR TITLE
QUA-688: Add exclude Pluging

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -276,6 +276,11 @@ markdown_extensions:
 
 plugins:
   - search
+  - exclude:
+      glob:
+      - components/anomaly-support/*
+      - components/comparators/*
+      - components/general-props/*
   - git-revision-date-localized
   - include-markdown
   - macros

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs-material==9.5.50
+mkdocs-exclude = "^1.0.2"
 mkdocs-git-revision-date-localized-plugin
 mkdocs-include-markdown-plugin==7.1.2
 mkdocs-macros-plugin==1.3.7


### PR DESCRIPTION

### Overview

<!-- Briefly describe the purpose of this PR. -->
This PR adds a new plugin to prevent component documentation content from appearing in User Guide search results, improving search relevance.

### Key Changes

<!-- List the key features or bug fixes. Add a brief description if needed. -->
- Added search exclusion plugin: Implemented plugin to exclude component documentation from User Guide search indexing
- Excluded documentation paths: The following component docs are now excluded from search:
  - `docs/components/anomaly-support/index.md`
  - `docs/components/comparators/duration.md`
  - `docs/components/comparators/index.md`
  - `docs/components/comparators/numeric.md`
  - `docs/components/comparators/string.md`
  - `docs/components/general-props/filter-guide.md`
  - `docs/components/general-props/index.md`

