### PR TITLE
QUA-753: Block not allowed users from merge the PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# These individuals will be requested for
+# review when someone opens a pull request.
+*       @ets @josecsotomorales @gasscoelho @Hitsu-360 @shindiogawa @RafaelOsiro @sshpuntoff


### PR DESCRIPTION
### Overview

<!-- Briefly describe the purpose of this PR. -->
This PR includes the CODEOWNERS in project. This will block not allowed users from merge the PR

### Key Changes

<!-- List the key features or bug fixes. Add a brief description if needed. -->
- feat(codeowners): add file to block not allowed users to merge the PR…

### Screenshots

<!-- This section is optional. Attach screenshots if needed. -->
