### PR TITLE
Qua 943 update the is replica of warning message

### DIFF
--- a/docs/anomalies/source-record.md
+++ b/docs/anomalies/source-record.md
@@ -21,6 +21,6 @@ Users can view source records with selectable display limits of 10, 100, 1,000, 
 
 ## Comparison Source Records
 
-Anomalies identified by the Is Replica Of data quality rule type, configured with Row Identifiers, are displayed with a detailed source record comparison. This visualization highlights differences between rows, making it easier to identify specific discrepancies.
+Anomalies identified by the Data Diff rule type, configured with Row Identifiers, are displayed with a detailed source record comparison. This visualization highlights differences between rows, making it easier to identify specific discrepancies.
 
 ![is-replica](../assets/datastores/source-records/is-replica.png)

--- a/docs/checks/data-diff-check.md
+++ b/docs/checks/data-diff-check.md
@@ -1,5 +1,10 @@
 # Data Diff
 
+!!! info "Recommended Check"
+    Qualytics recommends using the `dataDiff` rule type instead of the `isReplicaOf`.
+    
+    The `isReplicaOf` check is sunsetting and will no longer be maintained, while `dataDiff` provides the same functionality with enhanced performance and additional capabilities.
+
 ### Definition
 
 *Asserts that the dataset created by the targeted field(s) matches the referred field(s) for data comparison.*

--- a/docs/checks/is-replica-of-check.md
+++ b/docs/checks/is-replica-of-check.md
@@ -1,33 +1,16 @@
 # Is Replica Of (_Is sunsetting_)
 
-!!! warning "Deprecation Warning"
-    This check is being deprecated and will be replaced by the [Data Diff](data-diff-check.md) check, which provides the same functionality with improved performance and features. 
+!!! warning "Deprecation Notice"
+    The `isReplicaOf` check is being deprecated and will no longer be maintained.
+    We strongly recommend using the [Data Diff](data-diff-check.md) check, which offers the same functionality with improved performance and additional features.
     
-    This change is a rename from `isReplicaOf` to `dataDiff`. The `isReplicaOf` checks that exist in your system will continue to exist but as a `dataDiff`.
-    Some things to keep in mind:
-    
-    1. Qualytics endpoint will no longer return the keyword `isReplicaOf`. You need to check if you have any pipeline or script that references that keyword specifically.
-    For example:
-    ```
-    data = response.json()
-    rule_type = data["rule_type"]
-    print(rule_type)  # prints dataDiff instead of isReplicaOf
-    ```
-    
-    2. The endpoint `GET /quality-checks/specifications/rules` will no longer return isReplicaOf, but dataDiff.
-    3. The violation message for anomalies was tweaked slightly.
-    Here's some example of violation message:
+    **Our recommendation:**
 
-        3.1 Shape Anomaly
-        ```
-        For `PART` and `PART_REPLICA`, differences were found between the targeted fields and the referred fields
-        ```
-        3.2 Record Anomaly
-        ```
-        There are 7 records that differ between `PART` (15 records) and `PART_REPLICA` (15 records) in `TPCH-1`
-        ```
+    - Consider using [`Data Diff`](data-diff-check.md) for new implementations
+    - `dataDiff` provides enhanced performance and additional capabilities
+    - Both checks will continue to coexist in the system
 
-    If you still need help [Contact our support team](mailto:support@qualytics.co)
+    If you have questions about this change, please [contact our support team](mailto:support@qualytics.co)
 
 ### Definition
 

--- a/docs/checks/overview-of-a-check.md
+++ b/docs/checks/overview-of-a-check.md
@@ -100,6 +100,7 @@ For more details about check rule types, please refer to the [**Rule Types Overv
 | [Contains Email](../checks/contains-email-check.md)                                   | Asserts that the values contain email addresses.                                                   |
 | [Contains Social Security Number](../checks/contains-social-security-number-check.md) | Asserts that the values contain social security numbers.                                 |
 | [Contains Url](../checks/contains-url.md)                                             | Asserts that the values contain valid URLs.                                                        |
+| [Data Diff](../checks/data-diff-check.md)                                   | Asserts that the dataset created by the targeted field(s) has differences compared to the referred field(s).                         |
 | [Distinct Count](../checks/distinct-count-check.md)                                   | Asserts on the approximate count distinct of the given column.                                      |
 | [Entity Resolution](../checks/entity-resolution.md)                                   | Asserts that every distinct entity is appropriately represented once and only once.                                                 |
 | [Equal To](../checks/equal-to-check.md)                                   | Asserts that all of the selected fields equal a value.                                                |
@@ -113,7 +114,7 @@ For more details about check rule types, please refer to the [**Rule Types Overv
 | [Greater Than Field](../checks/greater-than-field-check.md)                           | Asserts that this field is greater than another field.                                              |
 | [Is Address](../checks/is-address.md)                                                 | Asserts that the values contain the specified required elements of an address.|
 | [Is Credit Card](../checks/is-credit-card-check.md)                                   | Asserts that the values are credit card numbers.                                                    |
-| [Is Replica Of](../checks/is-replica-of-check.md)                                     | Asserts that the dataset created by the targeted field(s) is replicated by the referred field(s).     |
+| [Is Replica Of](../checks/is-replica-of-check.md) (_is sunsetting_)                      | Asserts that the dataset created by the targeted field(s) is replicated by the referred field(s).     |
 | [Is Type](../checks/is-type-check.md)                                                 | Asserts that the data is of a specific type.                                                       |
 | [Less Than](../checks/less-than-check.md)                                             | Asserts that the field is a number less than (or equal to) a value.                                 |
 | [Less Than Field](../checks/less-than-field-check.md)                                 | Asserts that this field is less than another field.                                                 |
@@ -136,5 +137,4 @@ For more details about check rule types, please refer to the [**Rule Types Overv
 | [Sum](../checks/sum-check.md)                                                         | Asserts that the sum of a field is a specific amount.                                               |
 | [Time Distribution Size](../checks/time-distribution-size-check.md)                   | Asserts that the count of records for each interval of a timestamp is between two numbers.          |
 | [Unique](../checks/unique-check.md)                                                   | Asserts that the field's value is unique.                                                           |
-| [User Defined Function](../checks/user-defined-function-check.md)                     | Asserts that the given user-defined function (as `Scala` script) evaluates to true over the field's value.|
 | [Volumetric](../checks/volumetric-check.md)                                          | Asserts that the data volume (rows or bytes) remains within dynamically inferred thresholds based on historical trends (daily, weekly, monthly).|

--- a/docs/checks/rule-types-overview.md
+++ b/docs/checks/rule-types-overview.md
@@ -17,6 +17,7 @@ Here’s an overview of the rule types and their purposes:
 | [Contains Email](../checks/contains-email-check.md)                                   | Asserts that the values contain email addresses.                                                   |
 | [Contains Social Security Number](../checks/contains-social-security-number-check.md) | Asserts that the values contain social security numbers.                                 |
 | [Contains Url](../checks/contains-url.md)                                             | Asserts that the values contain valid URLs.                                                        |
+| [Data Diff](../checks/data-diff-check.md)                                             | Asserts that the dataset created by the targeted field(s) has differences compared to the referred field(s). |
 | [Distinct Count](../checks/distinct-count-check.md)                                   | Asserts on the approximate count distinct of the given column.                                      |
 | [Entity Resolution](../checks/entity-resolution.md)                                   | Asserts that every distinct entity is appropriately represented once and only once                                                 |
 | [Equal To Field](../checks/equal-to-field-check.md)                                   | Asserts that this field is equal to another field.                                                 |
@@ -28,7 +29,7 @@ Here’s an overview of the rule types and their purposes:
 | [Greater Than Field](../checks/greater-than-field-check.md)                           | Asserts that this field is greater than another field.                                              |
 | [Is Address](../checks/is-address.md)                                                 | Asserts that the values contain the specified required elements of an address.|
 | [Is Credit Card](../checks/is-credit-card-check.md)                                   | Asserts that the values are credit card numbers.                                                    |
-| [Is Replica Of](../checks/is-replica-of-check.md)                                     | Asserts that the dataset created by the targeted field(s) is replicated by the referred field(s).     |
+| [Is Replica Of](../checks/is-replica-of-check.md) (_is sunsetting_)                   | Asserts that the dataset created by the targeted field(s) is replicated by the referred field(s).     |
 | [Is Type](../checks/is-type-check.md)                                                 | Asserts that the data is of a specific type.                                                       |
 | [Less Than](../checks/less-than-check.md)                                             | Asserts that the field is a number less than (or equal to) a value.                                 |
 | [Less Than Field](../checks/less-than-field-check.md)                                 | Asserts that this field is less than another field.                                                 |
@@ -50,5 +51,4 @@ Here’s an overview of the rule types and their purposes:
 | [Sum](../checks/sum-check.md)                                                         | Asserts that the sum of a field is a specific amount.                                               |
 | [Time Distribution Size](../checks/time-distribution-size-check.md)                   | Asserts that the count of records for each interval of a timestamp is between two numbers.          |
 | [Unique](../checks/unique-check.md)                                                   | Asserts that the field's value is unique.                                                           |
-| [User Defined Function](../checks/user-defined-function-check.md)                     | Asserts that the given user-defined function (as `Scala` script) evaluates to true over the field's value.|
 | [Volumetric Check](../checks/volumetric-check.md)                                     | Asserts that the volume of the data asset has not changed by more than an inclusive percentage amount for the prescribed moving daily average.|

--- a/docs/source-datastore/profile.md
+++ b/docs/source-datastore/profile.md
@@ -222,10 +222,11 @@ The following table shows the inferred checks that the Analytics Engine can gene
 
 | Inferred Checks | Reference |
 |-------|-------|
-| Predicted By | [See more.](https://userguide.qualytics.io/checks/predicted-by-check/) |
+| Data Diff | [See more.](../checks/data-diff-check.md) |
 | Exists In | [See more.](https://userguide.qualytics.io/checks/exists-in-check/) |
 | Not Exists In | [See more.](https://userguide.qualytics.io/checks/not-exists-in-check/) |
-| Is Replica Of | [See more.](https://userguide.qualytics.io/checks/is-replica-of-check/) |
+| Predicted By | [See more.](https://userguide.qualytics.io/checks/predicted-by-check/) |
+| Is Replica Of (_is sunsetting_) | [See more.](https://userguide.qualytics.io/checks/is-replica-of-check/) |
 
 ![inference-threshold-level4](../assets/profile-operations/inference-threshold-level4-light.png)
 

--- a/docs/weight/weighting.md
+++ b/docs/weight/weighting.md
@@ -22,10 +22,11 @@ These rules are assigned the highest weight of 3 to reflect their crucial role i
 | 6       | Contains Social Security Number | 3          |
 | 7       | Time Distribution Size          | 3          |
 | 8       | User Defined Function           | 3          |
-| 9       | Is Replica Of                   | 3          |
+| 9       | Is Replica Of (_is sunsetting_) | 3          |
 | 10      | Metric                          | 3          |
 | 11      | Aggregation Comparison          | 3          |
 | 12      | Is Address                      | 3          |
+| 14      | Data Diff                       | 3          |
 
 #### Medium Importance (Weight: 2)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
         - Contains Email: checks/contains-email-check.md
         - Contains Social Security Number: checks/contains-social-security-number-check.md
         - Contains Url: checks/contains-url.md
+        - Data Diff: checks/data-diff-check.md
         - Distinct Count: checks/distinct-count-check.md
         - Entity Resolution: checks/entity-resolution.md
         - Equal to: checks/equal-to-check.md
@@ -120,7 +121,6 @@ nav:
         - Is Address: checks/is-address.md
         - Is Credit Card: checks/is-credit-card-check.md
         - Is Replica Of: checks/is-replica-of-check.md
-        - Data Diff: checks/data-diff-check.md
         - Is Type: checks/is-type-check.md
         - Less Than: checks/less-than-check.md
         - Less Than Field: checks/less-than-field-check.md


### PR DESCRIPTION
### Overview

<!-- Briefly describe the purpose of this PR. -->
This PR includes the dataDiff and isReplicaOf warning message. Also were updated the documentation that is using `isReplicaOf` to `dataDiff`. Finally, was added the `is sunsetting` flag in `isReplicaOf` check

### Key Changes

<!-- List the key features or bug fixes. Add a brief description if needed. -->
- refactor: change the isReplicaOf and dataDiff warning message
- fix: change the `isReplicaOf` to `dataDiff`
- fix: add `is sunsetting` flag in `isReplicaOf` checks
- fix: sort the check rule types to asc

http://localhost:8001/checks/data-diff-check/
http://localhost:8001/checks/is-replica-of-check/
http://localhost:8001/anomalies/source-record/
http://localhost:8001/checks/overview-of-a-check/#check-rule-types
http://localhost:8001/checks/rule-types-overview/
http://localhost:8001/source-datastore/profile/
http://localhost:8001/weight/weighting/