### PR TITLE
QUA-1001: Add Enrichment Support column to all Source Datastore matrices

### DIFF
--- a/docs/add-datastores/overview-of-a-datastore.md
+++ b/docs/add-datastores/overview-of-a-datastore.md
@@ -55,27 +55,29 @@ Configure your source datastores in Qualytics by connecting them through a new d
 
 Qualytics supports a range of source datastores, including but not limited to:
 
-|          No. |                       Source Datastores |
-| :---- | :---- |
-|         1. |                         [Athena](../add-datastores/athena.md) |
-|         2. |                      [Databricks](../add-datastores/databricks.md) |
-|         3. |                          [DB2](../add-datastores/db2.md) |
-|         4. |                         [Hive](../add-datastores/hive.md) |
-|        5. |                      [MariaDB](../add-datastores/maria-db.md) |
-|        6. |              [Microsoft SQL Server](../add-datastores/microsoft-sql-server.md) |
-|        7. |                     [MySQL](../add-datastores/mysql.md) |
-|        8. |                     [Oracle](../add-datastores/oracle.md) |
-|        9.  |               [PostgreSQL](../add-datastores/postgresql.md) |
-|      10. |                   [Presto](../add-datastores/presto.md) |
-|      11. |            [Amazon Redshift](../add-datastores/redshift.md) |
-|      12. |               [Snowflake](../add-datastores/snowflake.md) |
-|      13. |                 [Synapse](../add-datastores/synapse.md) |
-|      14. |            [Timescale DB](../add-datastores/timescale-db.md) |
-|      15. |                  [Trino](../add-datastores/trino.md) |
-|      16.  |             [Dremio](../add-datastores/dremio.md) |
-|      17.  |             [Amazon S3](../add-datastores/amazon-s3.md) |
-|      18. |         [Google Cloud Storage](../add-datastores/google-cloud-storage.md) |
-|     19. |      [Azure Blob File System](../add-datastores/azure-datalake-storage.md) |
+| No. | Source Datastores | Enrichment Support |
+| :---- | :---- | :---- |
+| 1. | [Amazon Redshift](../add-datastores/redshift.md) | Yes |
+| 2.  | [Amazon S3](../add-datastores/amazon-s3.md) | Yes |
+| 3. | [Athena](../add-datastores/athena.md) | No |
+| 4. | [Azure Datalake Storage (ABFS)](../add-datastores/azure-datalake-storage.md) | Yes |
+| 5. | [Big Query](../add-datastores/bigquery.md) | Yes |
+| 6. | [Databricks](../add-datastores/databricks.md) | Yes |
+| 7. | [DB2](../add-datastores/db2.md) | Yes |
+| 8. | [Dremio](../add-datastores/dremio.md) | No |
+| 9. | [Google Cloud Storage](../add-datastores/google-cloud-storage.md) | Yes |
+| 10. | [Hive](../add-datastores/hive.md) | No |
+| 11. | [MariaDB](../add-datastores/maria-db.md) | Yes |
+| 12. | [Microsoft SQL Server](../add-datastores/microsoft-sql-server.md) | Yes |
+| 13. | [MySQL](../add-datastores/mysql.md) | Yes |
+| 14. | [Oracle](../add-datastores/oracle.md) | No |
+| 15. | [PostgreSQL](../add-datastores/postgresql.md) | Yes |
+| 16. | [Presto](../add-datastores/presto.md) | No |
+| 17. | [Snowflake](../add-datastores/snowflake.md) | Yes |
+| 18. | [Synapse](../add-datastores/synapse.md) | Yes |
+| 19. | [Teradata](../add-datastores/teradata.md) | No |
+| 20. | [Timescale DB](../add-datastores/timescale-db.md) | No |
+| 21. | [Trino](../add-datastores/trino.md) | Yes |
 
 ## Connection Management
 

--- a/docs/add-datastores/source-datastore.md
+++ b/docs/add-datastores/source-datastore.md
@@ -28,25 +28,26 @@ Qualytics integrates with these source datastores through a layered architecture
 
 Qualytics supports a range of source datastores, including but not limited to:
 
-|          No. |                       Source Datastores |
-| :---- | :---- |
-|         1. |                         [Athena](../add-datastores/athena.md) |
-|         2. |                      [Databricks](../add-datastores/databricks.md) |
-|         3. |                          [DB2](../add-datastores/db2.md) |
-|         4. |                         [Hive](../add-datastores/hive.md) |
-|        5. |                      [MariaDB](../add-datastores/maria-db.md) |
-|        6. |              [Microsoft SQL Server](../add-datastores/microsoft-sql-server.md) |
-|        7. |                     [MySQL](../add-datastores/mysql.md) |
-|        8. |                     [Oracle](../add-datastores/oracle.md) |
-|        9.  |               [PostgreSQL](../add-datastores/postgresql.md) |
-|      10. |                   [Presto](../add-datastores/presto.md) |
-|      11. |            [Amazon Redshift](../add-datastores/redshift.md) |
-|      12. |               [Snowflake](../add-datastores/snowflake.md) |
-|      13. |                 [Synapse](../add-datastores/synapse.md) |
-|      14. |            [Timescale DB](../add-datastores/timescale-db.md) |
-|      15. |                  [Trino](../add-datastores/trino.md) |
-|      16.  |             [Dremio](../add-datastores/dremio.md) |
-|      17.  |             [Amazon S3](../add-datastores/amazon-s3.md) |
-|      18. |         [Google Cloud Storage](../add-datastores/google-cloud-storage.md) |
-|     19. |      [Windows Azure Storage Blob](../add-datastores/azure-datalake-storage.md) |
-|     20. |        [Azure Blob File System](../add-datastores/azure-blob-storage.md) |
+| No. | Source Datastores | Enrichment Support |
+| :---- | :---- | :---- |
+| 1. | [Amazon Redshift](../add-datastores/redshift.md) | Yes |
+| 2. | [Amazon S3](../add-datastores/amazon-s3.md) | Yes |
+| 3. | [Athena](../add-datastores/athena.md) | No |
+| 4. | [Azure Datalake Storage (ABFS)](../add-datastores/azure-datalake-storage.md) | Yes |
+| 5. | [Big Query](../add-datastores/bigquery.md) | Yes |
+| 6. | [Databricks](../add-datastores/databricks.md) | Yes |
+| 7. | [DB2](../add-datastores/db2.md) | Yes |
+| 8. | [Dremio](../add-datastores/dremio.md) | No |
+| 9. | [Google Cloud Storage](../add-datastores/google-cloud-storage.md) | Yes |
+| 10. | [Hive](../add-datastores/hive.md) | No |
+| 11. | [MariaDB](../add-datastores/maria-db.md) | Yes |
+| 12. | [Microsoft SQL Server](../add-datastores/microsoft-sql-server.md) | Yes |
+| 13. | [MySQL](../add-datastores/mysql.md) | Yes |
+| 14. | [Oracle](../add-datastores/oracle.md) | No |
+| 15. | [PostgreSQL](../add-datastores/postgresql.md) | Yes |
+| 16. | [Presto](../add-datastores/presto.md) | No |
+| 17. | [Snowflake](../add-datastores/snowflake.md) | Yes |
+| 18. | [Synapse](../add-datastores/synapse.md) | Yes |
+| 19. | [Teradata](../add-datastores/teradata.md) | No |
+| 20. | [Timescale DB](../add-datastores/timescale-db.md) | No |
+| 21. | [Trino](../add-datastores/trino.md) | Yes |

--- a/docs/enrichment-support/supported-enrichment-datastores.md
+++ b/docs/enrichment-support/supported-enrichment-datastores.md
@@ -8,20 +8,20 @@ JDBC datastores in Qualytics make it easy to connect and manage data from relati
 
 | No. | JDBC Connector | Enrichment Support |
 | :---- | :---- | :---- |
-| 01. | [Athena](../add-datastores/athena.md#add-enrichment-datastore) | No |
-| 02. | [Big Query](../add-datastores/bigquery.md#add-enrichment-datastore) | Yes |
-| 03. | [Databricks](../add-datastores/databricks.md#add-enrichment-datastore) | Yes |
-| 04. | [DB2](../add-datastores/db2.md#add-enrichment-datastore) | No |
-| 05. | [Dremio](../add-datastores/dremio.md#add-enrichment-datastore) | No |
-| 06. | [Hive](../add-datastores/hive.md#add-enrichment-datastore) | No |
-| 07. | [MariaDB](../add-datastores/maria-db.md#add-enrichment-datastore) | Yes |
-| 08. | [Microsoft SQL](../add-datastores/microsoft-sql-server.md#add-enrichment-datastore) | Yes |
-| 09. | [MySQL](../add-datastores/mysql.md#add-enrichment-datastore) | Yes |
-| 10. | [Oracle](../add-datastores/oracle.md#add-enrichment-datastore) | No |
-| 11. | [PostgreSQL](../add-datastores/postgresql.md#add-enrichment-datastore) | Yes |
-| 12. | [Presto](../add-datastores/presto.md#add-enrichment-datastore) | No |
-| 13. | [Redshift](../add-datastores/redshift.md#add-enrichment-datastore) | Yes |
-| 14. | [Snowflake](../add-datastores/snowflake.md#add-enrichment-datastore-connection) | No |
+| 01. | [Amazon Redshift](../add-datastores/redshift.md#add-enrichment-datastore) | Yes |
+| 02. | [Athena](../add-datastores/athena.md#add-enrichment-datastore) | No |
+| 03. | [Big Query](../add-datastores/bigquery.md#add-enrichment-datastore) | Yes |
+| 04. | [Databricks](../add-datastores/databricks.md#add-enrichment-datastore) | Yes |
+| 05. | [DB2](../add-datastores/db2.md#add-enrichment-datastore) | Yes |
+| 06. | [Dremio](../add-datastores/dremio.md#add-enrichment-datastore) | No |
+| 07. | [Hive](../add-datastores/hive.md#add-enrichment-datastore) | No |
+| 08. | [MariaDB](../add-datastores/maria-db.md#add-enrichment-datastore) | Yes |
+| 09. | [Microsoft SQL Server](../add-datastores/microsoft-sql-server.md#add-enrichment-datastore) | Yes |
+| 10. | [MySQL](../add-datastores/mysql.md#add-enrichment-datastore) | Yes |
+| 11. | [Oracle](../add-datastores/oracle.md#add-enrichment-datastore) | No |
+| 12. | [PostgreSQL](../add-datastores/postgresql.md#add-enrichment-datastore) | Yes |
+| 13. | [Presto](../add-datastores/presto.md#add-enrichment-datastore) | No |
+| 14. | [Snowflake](../add-datastores/snowflake.md#add-enrichment-datastore-connection) | Yes |
 | 15. | [Synapse](../add-datastores/synapse.md#add-enrichment-datastore) | Yes |
 | 16. | [Teradata](../add-datastores/teradata.md#add-enrichment-datastore) | No |
 | 17. | [TimescaleDB](../add-datastores/timescale-db.md#add-enrichment-datastore) | No |

--- a/docs/enrichment-support/supported-enrichment-datastores.md
+++ b/docs/enrichment-support/supported-enrichment-datastores.md
@@ -6,33 +6,33 @@ Qualytics offers a variety of connectors, some of which support enrichment capab
 
 JDBC datastores in Qualytics make it easy to connect and manage data from relational databases. Using the JDBC API, you can establish secure connections, analyze data, and perform data profiling. This flexible feature supports a wide range of relational databases, making data discovery and quality checks seamless.
 
-|          No. |              JDBC Connector |      Enrichment Support |
+| No. | JDBC Connector | Enrichment Support |
 | :---- | :---- | :---- |
-|        01. |              [Big Query](../add-datastores/bigquery.md#add-enrichment-datastore) |             Yes |
-|        02. |              [Databricks](../add-datastores/databricks.md#add-enrichment-datastore) | Yes |
-|        03. |              [MariaDB](../add-datastores/maria-db.md#add-enrichment-datastore) | Yes |
-|        04. |              [Microsoft SQL](../add-datastores/microsoft-sql-server.md#add-enrichment-datastore) | Yes |
-|        05. |              [MySQL](../add-datastores/mysql.md#add-enrichment-datastore) |             Yes |
-|        06. |             [PostgreSQL](../add-datastores/postgresql.md#add-enrichment-datastore) | Yes |
-|        07. |             [Redshift](../add-datastores/redshift.md#add-enrichment-datastore) |             Yes |
-|        08. |             [Trino](../add-datastores/trino.md#add-enrichment-datastore) | Yes |
-|        09. |             [Athena](../add-datastores/athena.md#add-enrichment-datastore) | No |
-|        10. |             [DB2](../add-datastores/db2.md#add-enrichment-datastore) | No |
-|        11. |             [Hive](../add-datastores/hive.md#add-enrichment-datastore) | No |
-|        12. |             [Oracle](../add-datastores/oracle.md#add-enrichment-datastore) | No |
-|        13. |             [Presto](../add-datastores/presto.md#add-enrichment-datastore) | No |
-|        14. |             [Snowflake](../add-datastores/snowflake.md#add-enrichment-datastore-connection) |             No |
-|        15. |             [Synapse](../add-datastores/synapse.md#add-enrichment-datastore) |             No |
-|        16. |             [Teradata](../add-datastores/teradata.md#add-enrichment-datastore) |             No |
-|        17. |             [TimescaleDB](../add-datastores/timescale-db.md#add-enrichment-datastore) |             No |
-|        18. |             [Dremio](../add-datastores/dremio.md#add-enrichment-datastore) |             No |
+| 01. | [Athena](../add-datastores/athena.md#add-enrichment-datastore) | No |
+| 02. | [Big Query](../add-datastores/bigquery.md#add-enrichment-datastore) | Yes |
+| 03. | [Databricks](../add-datastores/databricks.md#add-enrichment-datastore) | Yes |
+| 04. | [DB2](../add-datastores/db2.md#add-enrichment-datastore) | No |
+| 05. | [Dremio](../add-datastores/dremio.md#add-enrichment-datastore) | No |
+| 06. | [Hive](../add-datastores/hive.md#add-enrichment-datastore) | No |
+| 07. | [MariaDB](../add-datastores/maria-db.md#add-enrichment-datastore) | Yes |
+| 08. | [Microsoft SQL](../add-datastores/microsoft-sql-server.md#add-enrichment-datastore) | Yes |
+| 09. | [MySQL](../add-datastores/mysql.md#add-enrichment-datastore) | Yes |
+| 10. | [Oracle](../add-datastores/oracle.md#add-enrichment-datastore) | No |
+| 11. | [PostgreSQL](../add-datastores/postgresql.md#add-enrichment-datastore) | Yes |
+| 12. | [Presto](../add-datastores/presto.md#add-enrichment-datastore) | No |
+| 13. | [Redshift](../add-datastores/redshift.md#add-enrichment-datastore) | Yes |
+| 14. | [Snowflake](../add-datastores/snowflake.md#add-enrichment-datastore-connection) | No |
+| 15. | [Synapse](../add-datastores/synapse.md#add-enrichment-datastore) | Yes |
+| 16. | [Teradata](../add-datastores/teradata.md#add-enrichment-datastore) | No |
+| 17. | [TimescaleDB](../add-datastores/timescale-db.md#add-enrichment-datastore) | No |
+| 18. | [Trino](../add-datastores/trino.md#add-enrichment-datastore) | Yes |
 
 ## DFS Connectors in Qualytics
 
 DFS datastores in Qualytics handle data stored in distributed file systems. These systems include Hadoop Distributed File System (HDFS) and similar large-scale storage solutions. With DFS connectors, you can easily access and enrich data from distributed environments.
 
-|            No. |               DFS Connector |   Enrichment Support |
+| No. |  DFS Connector | Enrichment Support |
 | :---- | :---- | :---- |
-|           1. |          [Amazon S3](../add-datastores/amazon-s3.md#add-enrichment-datastore) |            Yes |
-|           2. |           [Azure Datalake Storage](../add-datastores/azure-datalake-storage.md#add-enrichment-datastore) |            Yes |
-|           3. |          [Google Cloud Store](../add-datastores/google-cloud-storage.md#add-enrichment-datastore) |            Yes |
+| 1. | [Amazon S3](../add-datastores/amazon-s3.md#add-enrichment-datastore) | Yes |
+| 2. |  [Azure Datalake Storage (ABFS)](../add-datastores/azure-datalake-storage.md#add-enrichment-datastore) | Yes |
+| 3. | [Google Cloud Storage](../add-datastores/google-cloud-storage.md#add-enrichment-datastore) | Yes |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
         - add-datastores/azure-datalake-storage.md
         - add-datastores/google-cloud-storage.md
       - connections/overview-of-a-connection.md
+      - enrichment-support/supported-enrichment-datastores.md
     # new page tree structure end
     - Source Datastores:
       - Right Click Options: source-datastore/right-click-options.md


### PR DESCRIPTION
### Overview

<!-- Briefly describe the purpose of this PR. -->
This PR adds an "Enrichment Support" column to all Source Datastore matrices in the User Guide and standardizes datastore naming across the documentation.

### Key Changes
<!-- List the key features or bug fixes. Add a brief description if needed. -->
- Added Enrichment Support column: New column added to all Source Datastore matrices indicating enrichment capabilities
- Standardized datastore names: Fixed inconsistent naming to ensure uniform terminology throughout the project
- Expanded datastore list: Added missing datastores that were not previously documented in the matrices

### Screenshots

<!-- This section is optional. Attach screenshots if needed. -->

#### Add Datastore -> Source Datastore
<img width="2557" height="1254" alt="Screenshot 2025-09-22 at 13 18 42" src="https://github.com/user-attachments/assets/fe30467f-5599-46b0-abd6-b4194705eace" />

#### Integrations -> Source Datastore
<img width="2557" height="1254" alt="image" src="https://github.com/user-attachments/assets/7eb5ca2d-6116-4087-ae76-6a1fb5687ecb" />

#### Supported Enrichment Datastores
<img width="2557" height="1254" alt="image" src="https://github.com/user-attachments/assets/26226d79-9228-4b0b-b9cb-fd5c2c8821b8" />